### PR TITLE
FIX: pasar funcion a nueva api para evitar problemas al crear cliente con giro desde el pos

### DIFF
--- a/models/activity_description.py
+++ b/models/activity_description.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
-from odoo import fields, models, api, _
-import logging
 
-_logger = logging.getLogger(__name__)
+from odoo import fields, models, api, _
 
 class CreateActivity(models.Model):
     _inherit = 'sii.activity.description'
 
-    def create_from_ui(self, cr, uid,  partner, context=None):
-        obj = self.pool.get('sii.activity.description').create(cr, uid,
-            {'name': partner['activity_description']}, context=context)
-        return obj
+    @api.model
+    def create_from_ui(self, partner):
+        obj = self.env['sii.activity.description'].create({'name': partner['activity_description']})
+        return obj.id

--- a/static/src/js/pos_dte.js
+++ b/static/src/js/pos_dte.js
@@ -220,23 +220,6 @@ odoo.define('l10n_cl_dte_point_of_sale.pos_dte', function (require) {
            return;
        }
        if (fields.document_number ) {
-          fields.document_number = fields.document_number.toUpperCase().replace('.','').replace('.','');
-          var dv = fields.document_number.charAt(fields.document_number.length-1);
-          var entero = parseInt(fields.document_number.replace('-'+dv, ''));
-          if (entero < 10000000 ){
-            fields.document_number = '0' + entero;
-          }
-          var rut = '';
-          for(var c = 0; c < fields.document_number.replace('-','').length ; c++){
-            if (c === 2 || c === 5){
-              rut += '.';
-            }
-            if (c === 8 ){
-              rut += '-';
-            }
-            rut += fields.document_number[c];
-          }
-          fields.document_number = rut;
            if (!this.validar_rut(fields.document_number))
             {return;}
        }
@@ -370,6 +353,17 @@ odoo.define('l10n_cl_dte_point_of_sale.pos_dte', function (require) {
                select.val(selected_comuna);
                displayed_comuna.appendTo(select).show();
         });
+        self.$(".client-document_number").on('change', function(){
+    		var document_number = self.$(this).val() || '';
+    		document_number = document_number.replace(/[^1234567890Kk]/g, "");
+    		document_number = _.str.lpad(document_number, 9, '0');
+    		document_number = _.str.sprintf('%s.%s.%s-%s',  
+    				document_number.slice(0, 2), 
+    				document_number.slice(2, 5),
+    				document_number.slice(5, 8),
+    				document_number.slice(-1))
+    		self.$(this).val(document_number);
+    	});
         self.$("select[name='country_id']").change();
         self.$("select[name='state_id']").change();
        }

--- a/static/src/js/pos_dte.js
+++ b/static/src/js/pos_dte.js
@@ -297,8 +297,7 @@ odoo.define('l10n_cl_dte_point_of_sale.pos_dte', function (require) {
                     function(partner_id){
                       self.saved_client_details(partner_id);
                     },
-                    function(err,event){
-                      event.preventDefault();
+                    function(err_type, err){
                       if (err.data.message) {
                         self.gui.show_popup('error',{
                          'title': _t('Error: Could not Save Changes partner'),
@@ -312,8 +311,7 @@ odoo.define('l10n_cl_dte_point_of_sale.pos_dte', function (require) {
                       }
                     });
             },
-            function(err,event){
-             event.preventDefault();
+            function(err_type, err){
              if (err.data.message) {
                 self.gui.show_popup('error',{
                          'title': _t('Error: Could not Save Changes'),
@@ -335,8 +333,7 @@ odoo.define('l10n_cl_dte_point_of_sale.pos_dte', function (require) {
           }).then(
             function(partner_id){
              self.saved_client_details(partner_id);
-            },function(err,event){
-             event.preventDefault();
+            },function(err_type, err){
               if (err.data.message) {
                 self.gui.show_popup('error',{
                        'title': _t('Error: Could not Save Changes'),


### PR DESCRIPTION
FIX: rpc.query cuando hay error no devuelve Event y no se puede usar preventDefault, siempre va a devolver el tipo de error=server y el detalle del error [ver codigo aca](https://github.com/odoo/odoo/blob/11.0/addons/web/static/src/js/core/ajax.js#L22)