### PR TITLE
IMP: configuracion para entorno multi tiendas

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -33,9 +33,11 @@ Chile: API and GUI to access Electronic Invoicing webservices for Point of Sale.
         'views/point_of_sale.xml',
         'views/bo_receipt.xml',
         'views/portal_boleta_layout.xml',
+        'views/res_users_view.xml',
         'wizard/masive_send_dte.xml',
 #        'data/sequence.xml',
         'security/ir.model.access.csv',
+        'security/rule_security.xml',
     ],
     'qweb': [
         'static/src/xml/layout.xml',

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,3 +4,4 @@ from . import point_of_sale
 from . import pos_config
 from . import pos_session
 from . import activity_description
+from . import res_users

--- a/models/res_users.py
+++ b/models/res_users.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, api, fields, tools
+import odoo.addons.decimal_precision as dp
+from odoo.tools.translate import _
+
+class ResUsers(models.Model):
+
+    _inherit = 'res.users'
+    
+    pos_config_ids = fields.Many2many('pos.config', 'pos_config_users_rel', 
+        'user_id', 'config_id', u'TPV permitidos')
+    
+    @api.multi
+    def write(self, values):
+        res = super(ResUsers, self).write(values)
+        # clear caches linked to the users
+        if 'pos_config_ids' in values:
+            self.env['ir.model.access'].call_cache_clearing_methods()
+            self.env['ir.rule'].clear_caches()
+            self.has_group.clear_cache(self)
+        return res
+    
+    @api.model
+    def get_all_warehouse(self, user_id=None):
+        if not user_id:
+            user_id = self.env.uid
+        user = self.sudo().browse(user_id)
+        warehouse_recs = self.env['stock.warehouse'].browse()
+        for config in user.pos_config_ids:
+            if config.warehouse_id:
+                warehouse_recs |= config.warehouse_id
+        return warehouse_recs
+    
+    @api.model
+    def get_all_location(self, user_id=None):
+        if not user_id:
+            user_id = self.env.uid
+        user = self.sudo().browse(user_id)
+        location_recs = self.env['stock.location'].browse()
+        for config in user.pos_config_ids:
+            if config.stock_location_id:
+                location_recs  |= config.stock_location_id
+            warehouse = config.warehouse_id
+            if warehouse.lot_stock_id:
+                location_recs |= warehouse.lot_stock_id
+            if warehouse.wh_input_stock_loc_id:
+                location_recs |= warehouse.wh_input_stock_loc_id
+            if warehouse.wh_qc_stock_loc_id:
+                location_recs |= warehouse.wh_qc_stock_loc_id
+            if warehouse.wh_output_stock_loc_id:
+                location_recs |= warehouse.wh_output_stock_loc_id
+            if warehouse.wh_pack_stock_loc_id:
+                location_recs |= warehouse.wh_pack_stock_loc_id
+        return location_recs
+    
+    @api.model
+    def get_all_picking_type(self, user_id=None):
+        if not user_id:
+            user_id = self.env.uid
+        user = self.sudo().browse(user_id)
+        picking_type_recs = self.env['stock.picking.type']
+        for config in user.pos_config_ids:
+            if config.picking_type_id:
+                picking_type_recs |= config.picking_type_id
+            if config.warehouse_id:
+                picking_type_recs |= config.warehouse_id.pick_type_id
+                picking_type_recs |= config.warehouse_id.pack_type_id
+                picking_type_recs |= config.warehouse_id.out_type_id
+                picking_type_recs |= config.warehouse_id.in_type_id
+                picking_type_recs |= config.warehouse_id.int_type_id
+        return picking_type_recs

--- a/security/rule_security.xml
+++ b/security/rule_security.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+	<data noupdate="1">
+		<record id="pos_config_user_rule" model="ir.rule">
+			<field name="name">TPV permitidos por Usuario</field>
+			<field name="model_id" ref="point_of_sale.model_pos_config" />
+			<field name="groups" eval="[(4, ref('point_of_sale.group_pos_user'))]" />
+			<field name="domain_force">[("id","in",user.pos_config_ids.ids)]</field>
+			<field name="perm_create" eval="False" />
+			<field name="perm_unlink" eval="False" />
+			<field name="perm_write" eval="False" />
+		</record>
+
+		<record id="pos_config_manager_rule" model="ir.rule">
+			<field name="name">Ver todos los TPV</field>
+			<field name="model_id" ref="point_of_sale.model_pos_config" />
+			<field name="groups" eval="[(4, ref('point_of_sale.group_pos_manager'))]" />
+			<field name="domain_force">[(1,"=",1)]</field>
+			<field name="perm_create" eval="False" />
+			<field name="perm_unlink" eval="False" />
+			<field name="perm_write" eval="False" />
+		</record>
+
+	</data>
+</odoo>

--- a/views/res_users_view.xml
+++ b/views/res_users_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+	<data>
+		<record id="res_users_form_view" model="ir.ui.view">
+			<field name="name">res.users.form</field>
+			<field name="model">res.users</field>
+			<field name="inherit_id" ref="point_of_sale.res_users_form_view" />
+			<field name="arch" type="xml">
+				<field name="barcode" position="before">
+					<field name="pos_config_ids" options="{'no_create': True, 'no_open': True}"
+						widget="many2many_tags" />
+				</field>
+			</field>
+		</record>
+
+	</data>
+</odoo>


### PR DESCRIPTION
El siguiente PR pretende facilitar la configuracion en ambiente multitiendas, pudiendo configurar en los usuarios los TPV a los que tienen acceso y de esta manera no ver TPV de otras tiendas.

Adjunto algunos screen del antes y despues:

BD con dos TPV simulando q son dos tiendas geograficamente distantes
![image](https://user-images.githubusercontent.com/7775116/35835901-6aca3fd2-0aab-11e8-8dd1-44ffa8eaa7f4.png)

un usuario del TPV puede ver todos los TPV
![image](https://user-images.githubusercontent.com/7775116/35835930-96ae235c-0aab-11e8-8da2-80170c29ce98.png)

En escenarios donde se desea que un usuario no vea los datos de otros TPV, se puede agregar reglas de registro y cumplir con este proposito, pero creo que es mejor que el modulo traiga esto por defecto.
![image](https://user-images.githubusercontent.com/7775116/35836007-e6fff556-0aab-11e8-9a24-c9d774109c7f.png)

El resultado es el siguiente:
![image](https://user-images.githubusercontent.com/7775116/35836022-ff65e7cc-0aab-11e8-9555-3f516205ce1b.png)

En el usuario se puede agregar uno o mas TPV que seran los que el vera. 

Este PR me gustaria que le hagas merge xq considero algo importante para ambiente multitiendas, y seria bueno tenerlo en el modulo base de la localizacion chilena, sin embargo respeto tu punto de vista como has mencionado en un issue que cree, si no lo agregas aca, tendre que ponerlo en un modulo aparte para nuestro uso, pero repito, seria bueno tenerlo de base en la localizacion.
Cualquier comentario o mejora estoy atento.