### PR TITLE
IMP: tomar correctamente el siguiente folio disponible cuando se acaba un caf y hay mas CAF

### DIFF
--- a/static/src/js/models.js
+++ b/static/src/js/models.js
@@ -190,6 +190,12 @@ models.PosModel = models.PosModel.extend({
 	refresh_numero_ordenes: function(session_data) {
 		this.pos_session.numero_ordenes = session_data.numero_ordenes || 0;
 		this.pos_session.numero_ordenes_exentas = session_data.numero_ordenes_exentas || 0;
+		if (session_data.start_number){
+			this.pos_session.start_number = session_data.start_number;
+		}
+		if (session_data.start_number_exentas){
+			this.pos_session.start_number_exentas = session_data.start_number_exentas;
+		}
 	},
 	
 	/** 
@@ -219,7 +225,7 @@ models.PosModel = models.PosModel.extend({
 	    		var params = {
                     model: 'pos.session',
                     method: 'read',
-                    args: [[self.pos_session.id],['numero_ordenes', 'numero_ordenes_exentas']],
+                    args: [[self.pos_session.id],['numero_ordenes', 'numero_ordenes_exentas', 'start_number', 'start_number_exentas']],
                 };
 	    		return PosModelSuper.push_order.call(this, null, opts).done(function() {
 	    			rpc.query(params).then(function(result){

--- a/static/src/js/models.js
+++ b/static/src/js/models.js
@@ -176,7 +176,7 @@ models.PosModel = models.PosModel.extend({
 	 * Esto para calcular folios correctamente 
 	 * cuando se envian pedidos que se quedaron en cola
 	 */
-	refres_numero_ordenes: function(session_data) {
+	refresh_numero_ordenes: function(session_data) {
 		this.pos_session.numero_ordenes = session_data.numero_ordenes || 0;
 		this.pos_session.numero_ordenes_exentas = session_data.numero_ordenes_exentas || 0;
 	},
@@ -213,7 +213,7 @@ models.PosModel = models.PosModel.extend({
 	    		return PosModelSuper.push_order.call(this, null, opts).done(function() {
 	    			rpc.query(params).then(function(result){
     					if (result.length > 0){
-    						self.refres_numero_ordenes(result[0]);
+    						self.refresh_numero_ordenes(result[0]);
     					}
     					framework.unblockUI();
 	    			}, function(err){

--- a/static/src/js/screens.js
+++ b/static/src/js/screens.js
@@ -65,7 +65,7 @@ screens.PaymentScreenWidget.include({
 			}
 			var caf_files = JSON.parse(order.sequence_id.caf_files);
 			var next_number = start_number + numero_ordenes;
-			next_number = self.pos.get_next_number(next_number, caf_files, start_number);
+			next_number = self.pos.get_next_number(order, next_number, caf_files);
 			var caf_file = false;
 			for (var x in caf_files){
 				if(next_number >= caf_files[x].AUTORIZACION.CAF.DA.RNG.D && next_number <= caf_files[x].AUTORIZACION.CAF.DA.RNG.H){


### PR DESCRIPTION
IMP: tomar correctamente el siguiente folio disponible cuando se acaba un caf y hay mas CAF
IMP: cuando en JS se toma siguiente folio, en el server deben refrescarse los datos de la sesion, usar bandera force_sii_document_number para saber cuando hay que actualizar

Esta es la solucion para el bug #29  por favor probar  y hacer merge.
Nota: este PR depende del PR #30 asi que creo que seria mejor hacer el merge a ese PR y luego a este PR. Ambos PR solucionan dos bug que son independientes, pero se modifica la misma funcion get_next_number y  push_order por ello podria haber conflictos.

Me avisas si tienes problemas con el merge y lo corregimos