### PR TITLE
FIX: evitar errores cuando se inicia desde el folio 1 en BD nueva

### DIFF
--- a/models/point_of_sale.py
+++ b/models/point_of_sale.py
@@ -797,8 +797,6 @@ version="1.0">
         type = 'bol'
         einvoice = self.env['account.invoice'].sign_full_xml(
                 envelope_efact,
-                signature_d['priv_key'],
-                self.split_cert(certp),
                 doc_id_number,
                 type,
             )

--- a/static/src/js/models.js
+++ b/static/src/js/models.js
@@ -204,6 +204,9 @@ models.Order = models.Order.extend({
 			this.signature = this.signature || false;
 			this.sii_document_number = this.sii_document_number || false;
 			this.orden_numero = this.orden_numero || this.pos.pos_session.numero_ordenes;
+			if (this.orden_numero <= 0){
+				this.orden_numero = 1;
+			}
 		}
 	},
 	export_as_JSON: function() {

--- a/static/src/js/models.js
+++ b/static/src/js/models.js
@@ -260,7 +260,7 @@ models.Order = models.Order.extend({
 	},
 	initialize_validation_date: function(){
 		_super_order.initialize_validation_date.apply(this,arguments);
-		if (!this.is_to_invoice() && this.es_boleta() && this.finalized){
+		if (!this.is_to_invoice() && this.es_boleta() && !this.finalized){
 			if(this.es_boleta_exenta()){
 				this.pos.pos_session.numero_ordenes_exentas ++;
 				this.orden_numero = this.pos.pos_session.numero_ordenes_exentas;


### PR DESCRIPTION
Cuando se inicia con un CAF desde el folio 1, no hay pedidos de venta en la sesion actual(por lo general una BD nueva), sale error desconocido, xq en [esta linea de codigo](https://github.com/dansanti/l10n_cl_dte_point_of_sale/blob/11.0/static/src/js/models.js#L206) se inicializa los valores con el numero de ordenes vendidas en el pos o el numero de ordenes de la sesion, en este caso ambos valores son 0, por lo que se queda con un valor 0, pero al validar el pedido en el pos y tomar el siguiente numero disponible([en esta parte de codigo](https://github.com/dansanti/l10n_cl_dte_point_of_sale/blob/11.0/static/src/js/models.js#L173)) se hace una resta de 1, quedando 0 -1 = -1, un valor negativo.
Cuando sea valor 0 pasar 1 para que al hacer la resta, no sea un valor negativo sino 0 y asi se de el siguiente numero de folio correctamente.