### PR TITLE
IMP: seleccionar comuna y completar datos de provincia, pais, para fa…

### DIFF
--- a/static/src/js/models.js
+++ b/static/src/js/models.js
@@ -110,9 +110,13 @@ models.load_models({
 
 models.load_models({
 	model: 'res.city',
-	fields: ['id', 'name', 'state_id'],
+	fields: ['id', 'name', 'state_id', 'country_id'],
 		loaded: function(self, ct){
 			self.cities = ct;
+			self.cities_by_id = {};
+            _.each(ct, function(city){
+                self.cities_by_id[city.id] = city;
+            });
 		},
 });
 

--- a/static/src/js/models.js
+++ b/static/src/js/models.js
@@ -16,7 +16,7 @@ for(var i=0; i<modules.length; i++){
 		model.fields.push('activity_description','street','city', 'dte_resolution_date', 'dte_resolution_number');
 	}
 	if(model.model === 'res.partner'){
-		model.fields.push('document_number','activity_description','document_type_id', 'state_id', 'city_id');
+		model.fields.push('document_number','activity_description','document_type_id', 'state_id', 'city_id', 'dte_email');
 	}
 	if(model.model === 'pos.session'){
 		model.fields.push('caf_files', 'caf_files_exentas', 'start_number', 'start_number_exentas', 'numero_ordenes', 'numero_ordenes_exentas');

--- a/static/src/js/screens.js
+++ b/static/src/js/screens.js
@@ -271,14 +271,17 @@ screens.ClientListScreenWidget.include({
 				select.val(selected_state);
 				displayed_state.appendTo(select).show();
 			});
-			self.$("select[name='state_id']").on('change', function(){
-				var select = self.$("select[name='city_id']:visible");
-				var selected_comuna = select.val();
-				comuna_options.detach();
-				var displayed_comuna = comuna_options.filter("[data-state_id="+(self.$(this).val() || 0)+"]");
-				select.val(selected_comuna);
-				displayed_comuna.appendTo(select).show();
-			});
+			self.$("select[name='city_id']").on('change', function(){
+        		var city_id = self.$(this).val() || 0;
+        		if (city_id > 0){
+        			var city = self.pos.cities_by_id[city_id];
+        			var select_country = self.$("select[name='country_id']:visible");
+        			select_country.val(city.country_id ? city.country_id[0] : 0);
+        			select_country.change();
+        			var select_state = self.$("select[name='state_id']:visible");
+        			select_state.val(city.state_id ? city.state_id[0] : 0);
+        		}
+        	});
 			self.$(".client-document_number").on('change', function(){
 				var document_number = self.$(this).val() || '';
 				document_number = document_number.replace(/[^1234567890Kk]/g, "");
@@ -291,7 +294,6 @@ screens.ClientListScreenWidget.include({
     			self.$(this).val(document_number);
 			});
 			self.$("select[name='country_id']").change();
-			self.$("select[name='state_id']").change();
 		}
 	},
 	validar_rut: function(texto){

--- a/static/src/xml/client.xml
+++ b/static/src/xml/client.xml
@@ -1,130 +1,151 @@
 <?xml version="1.0" encoding="utf-8"?>
-<templates id="template_client" inherit_id="point_of_sale.template" name="Template_client">
-    <t t-extend="ClientDetailsEdit">
-        <t t-jquery="div.client-details-left" t-operation="replace">
-        	<div class='client-details-left'>
-	       	<div class='client-detail'>
+<templates id="template_client" inherit_id="point_of_sale.template"
+	name="Template_client">
+	<t t-extend="ClientDetailsEdit">
+		<t t-jquery="div.client-details-left" t-operation="replace">
+			<div class='client-details-left'>
+				<div class='client-detail'>
 					<span class='label'>Tipo Documento</span>
-	               <select class='detail client-address-document_type_id' name='document_type_id'>
-	                   <option value=''>None</option>
-	                   <t t-foreach='widget.pos.sii_document_types' t-as='sii_document_type'>
-	                       <option t-att-value='sii_document_type.id' t-att-selected="partner.document_type_id ? ((sii_document_type.id === partner.document_type_id[0]) ? true : undefined) : (sii_document_type.sii_code ===  81 ? true: undefined)">
-	                           <t t-esc='sii_document_type.name'/>
-	                       </option>
-	                   </t>
-	               </select>
+					<select class='detail client-address-document_type_id' name='document_type_id'>
+						<option value=''>None</option>
+						<t t-foreach='widget.pos.sii_document_types' t-as='sii_document_type'>
+							<option t-att-value='sii_document_type.id'
+								t-att-selected="partner.document_type_id ? ((sii_document_type.id === partner.document_type_id[0]) ? true : undefined) : (sii_document_type.sii_code ===  81 ? true: undefined)">
+								<t t-esc='sii_document_type.name' />
+							</option>
+						</t>
+					</select>
 				</div>
-	       	<div class='client-detail'>
+				<div class='client-detail'>
 					<span class='label'>RUT</span>
-					<input class='detail client-document_number' name='document_number' t-att-value='partner.document_number' placeholder='RUT'></input>
+					<input class='detail client-document_number' name='document_number'
+						t-att-value='partner.document_number' placeholder='RUT'></input>
 				</div>
-       	<div class='client-detail' t-if="partner.activity_description">
+				<div class='client-detail' t-if="partner.activity_description">
 					<span class='label'>Giro</span>
-	               <select class='detail client-address-activity_description' name='activity_description'>
-	                   <option value=''>None</option>
-	                   <t t-foreach='widget.pos.sii_activities' t-as='sii_activity'>
-	                       <option t-att-value='sii_activity.id' t-att-selected="partner.activity_description ? ((sii_activity.id === partner.activity_description[0]) ? true : undefined) : undefined">
-	                           <t t-esc='sii_activity.name'/>
-	                       </option>
-	                   </t>
-	               </select>
+					<select class='detail client-address-activity_description'
+						name='activity_description'>
+						<option value=''>None</option>
+						<t t-foreach='widget.pos.sii_activities' t-as='sii_activity'>
+							<option t-att-value='sii_activity.id'
+								t-att-selected="partner.activity_description ? ((sii_activity.id === partner.activity_description[0]) ? true : undefined) : undefined">
+								<t t-esc='sii_activity.name' />
+							</option>
+						</t>
+					</select>
 				</div>
-        <div class='client-detail' t-if="!partner.activity_description">
+				<div class='client-detail' t-if="!partner.activity_description">
 					<span class='label'>Giro</span>
-	               <input class='detail client-address-activity_description' name='activity_description' placeholder="Crear nueva Descripción del giro" ></input>
-         </div>
-        <div class='client-detail'>
+					<input class='detail client-address-activity_description'
+						name='activity_description' placeholder="Crear nueva Descripción del giro"></input>
+				</div>
+				<div class='client-detail'>
 					<span class='label'>Responsabilidad</span>
-	               <select class='detail client-responsability' name='responsability_id'>
-	                   <option value=''>None</option>
-	                   <t t-foreach='widget.pos.responsabilities' t-as='resp'>
-	                       <option t-att-value='resp.id' t-att-selected="partner.responsability_id ? ((resp.id === partner.responsability_id[0]) ? true : undefined) : (resp.tp_sii_code === 1 ? true: undefined)">
-	                           <t t-esc='resp.name'/>
-	                       </option>
-	                   </t>
-	               </select>
+					<select class='detail client-responsability' name='responsability_id'>
+						<option value=''>None</option>
+						<t t-foreach='widget.pos.responsabilities' t-as='resp'>
+							<option t-att-value='resp.id'
+								t-att-selected="partner.responsability_id ? ((resp.id === partner.responsability_id[0]) ? true : undefined) : (resp.tp_sii_code === 1 ? true: undefined)">
+								<t t-esc='resp.name' />
+							</option>
+						</t>
+					</select>
 				</div>
-	       	<div class='client-detail'>
-	               <span class='label'>Country</span>
-	               <select class='detail client-address-country' name='country_id'>
-	                   <option value=''>None</option>
-	                   <t t-foreach='widget.pos.countries' t-as='country'>
-	                       <option t-att-value='country.id' t-att-selected="partner.country_id ? ((country.id === partner.country_id[0]) ? true : undefined) : undefined">
-	                           <t t-esc='country.name'/>
-	                       </option>
-	                   </t>
-	               </select>
-	           </div>
-	           <div class='client-detail'>
-	              <span class='label'>Provincia</span>
-	              <select class='detail client-address-state_id' name='state_id'>
-	                  <option value=''>None</option>
-	                  <t t-foreach='widget.pos.states' t-as='state'>
-	                      <option t-att-value='state.id' t-att-data-country_id="state.country_id[0]" t-att-selected="partner.state_id ? ((state.id === partner.state_id[0]) ? true : undefined) : undefined">
-	                          <t t-esc='state.name'/>
-	                      </option>
-	                  </t>
-	              </select>
-	          </div>
-	           <div class='client-detail'>
-	              <span class='label'>Comuna</span>
-	              <select class='detail client-address-city_id' name='city_id'>
-	                  <option value=''>None</option>
-	                  <t t-foreach='widget.pos.cities' t-as='city'>
-	                      <option t-att-value='city.id' t-att-data-state_id="city.state_id[0]" t-att-selected="partner.city_id ? ((city.id === partner.city_id[0]) ? true : undefined) : undefined">
-	                          <t t-esc='city.name'/>
-	                      </option>
-	                  </t>
-	              </select>
-	          </div>
-            <div class='client-detail'>
-                <span class='label'>City</span>
-                <input class='detail client-address-city'   name='city'         t-att-value='partner.city' placeholder='City'></input>
-            </div>
-	          <div class='client-detail'>
-	               <span class='label'>Street</span>
-	               <input class='detail client-address-street' name='street'       t-att-value='partner.street' placeholder='Street'></input>
-	           </div>
-           </div>
-        </t>
-        <t t-jquery="div.client-details-right div:first-child" t-operation="after">
-        	<div class='client-detail'>
-                <span class='label'>DTE Email</span>
-                <input class='detail client-dte_email'  name='dte_email'    type='email'    t-att-value='partner.dte_email || ""'></input>
-            </div>
-        </t>
-        <t t-jquery="span:contains('Tax ID')" t-operation="replace" >
-        	<span class='label'>VAT</span>
-        </t>
-    </t>
+				<div class='client-detail'>
+					<span class='label'>Comuna</span>
+					<select class='detail client-address-city_id' name='city_id'>
+						<option value=''>None</option>
+						<t t-foreach='widget.pos.cities' t-as='city'>
+							<option t-att-value='city.id' t-att-data-state_id="city.state_id[0]"
+								t-att-selected="partner.city_id ? ((city.id === partner.city_id[0]) ? true : undefined) : undefined">
+								<t t-esc='city.name' />
+							</option>
+						</t>
+					</select>
+				</div>
+				<div class='client-detail'>
+					<span class='label'>City</span>
+					<input class='detail client-address-city' name='city'
+						t-att-value='partner.city' placeholder='City'></input>
+				</div>
+				<div class='client-detail'>
+					<span class='label'>Street</span>
+					<input class='detail client-address-street' name='street'
+						t-att-value='partner.street' placeholder='Street'></input>
+				</div>
 
-    <t t-extend="ClientDetails">
-        <t t-jquery="div.client-details-left div:first-child" t-operation="before">
-            <div class='client-detail'>
+				<div class='client-detail'>
+					<span class='label'>Country</span>
+					<select class='detail client-address-country' name='country_id'>
+						<option value=''>None</option>
+						<t t-foreach='widget.pos.countries' t-as='country'>
+							<option t-att-value='country.id'
+								t-att-selected="partner.country_id ? ((country.id === partner.country_id[0]) ? true : undefined) : undefined">
+								<t t-esc='country.name' />
+							</option>
+						</t>
+					</select>
+				</div>
+				<div class='client-detail'>
+					<span class='label'>Provincia</span>
+					<select class='detail client-address-state_id' name='state_id'>
+						<option value=''>None</option>
+						<t t-foreach='widget.pos.states' t-as='state'>
+							<option t-att-value='state.id' t-att-data-country_id="state.country_id[0]"
+								t-att-selected="partner.state_id ? ((state.id === partner.state_id[0]) ? true : undefined) : undefined">
+								<t t-esc='state.name' />
+							</option>
+						</t>
+					</select>
+				</div>
+			</div>
+		</t>
+		<t t-jquery="div.client-details-right div:first-child" t-operation="after">
+			<div class='client-detail'>
+				<span class='label'>DTE Email</span>
+				<input class='detail client-dte_email' name='dte_email' type='email'
+					t-att-value='partner.dte_email || ""'></input>
+			</div>
+		</t>
+		<t t-jquery="span:contains('Tax ID')" t-operation="replace">
+			<span class='label'>VAT</span>
+		</t>
+	</t>
+
+	<t t-extend="ClientDetails">
+		<t t-jquery="div.client-details-left div:first-child" t-operation="before">
+			<div class='client-detail'>
 				<span class='label'>RUT</span>
-				<span class='detail client-document_number'><t t-esc='partner.document_number || ""' /></span>
+				<span class='detail client-document_number'>
+					<t t-esc='partner.document_number || ""' />
+				</span>
 			</div>
-        </t>
-        <t t-jquery="div.client-details-left div:first-child" t-operation="after">
-            <div class='client-detail'>
+		</t>
+		<t t-jquery="div.client-details-left div:first-child" t-operation="after">
+			<div class='client-detail'>
 				<span class='label'>Giro</span>
-				<span class='detail client-activity_description'><t t-esc='partner.activity_description ? partner.activity_description[1] : ""' /></span>
+				<span class='detail client-activity_description'>
+					<t
+						t-esc='partner.activity_description ? partner.activity_description[1] : ""' />
+				</span>
 			</div>
-        </t>
-        <t t-jquery="span:contains('Tax ID')" t-operation="replace" >
-        	<span class='label'>VAT</span>
-        </t>
-    </t>
+		</t>
+		<t t-jquery="span:contains('Tax ID')" t-operation="replace">
+			<span class='label'>VAT</span>
+		</t>
+	</t>
 
-	   <t t-extend="ClientListScreenWidget">
-        <t t-jquery="table.client-list thead tr th:first-child" t-operation="before">
-            <th style="width: 120px;">RUT</th>
-        </t>
-    </t>
-    <t t-extend="ClientLine">
-        <t t-jquery="tr td:first-child" t-operation="before">
-            <td><t t-esc='partner.document_number or "Sin Rut"' /></td>
-        </t>
-    </t>
+	<t t-extend="ClientListScreenWidget">
+		<t t-jquery="table.client-list thead tr th:first-child" t-operation="before">
+			<th style="width: 120px;">RUT</th>
+		</t>
+	</t>
+	<t t-extend="ClientLine">
+		<t t-jquery="tr td:first-child" t-operation="before">
+			<td>
+				<t t-esc='partner.document_number or "Sin Rut"' />
+			</td>
+		</t>
+	</t>
 
 </templates>

--- a/static/src/xml/client.xml
+++ b/static/src/xml/client.xml
@@ -130,6 +130,17 @@
 				</span>
 			</div>
 		</t>
+		<t t-jquery="t[t-if='!partner.email']" t-operation="after">
+			<div class='client-detail'>
+				<span class='label'>DTE Email</span>
+				<t t-if='partner.email'>
+					<span class='detail client-dte_email'><t t-esc='partner.dte_email || ""' /></span>
+				</t>
+				<t t-if='!partner.email'>
+					<span class='detail client-dte_email empty'>N/A</span>
+				</t>
+			</div>
+		</t>
 		<t t-jquery="span:contains('Tax ID')" t-operation="replace">
 			<span class='label'>VAT</span>
 		</t>


### PR DESCRIPTION
…cilitar la creacion de clientes desde el pos

Los usuarios trabajan mas a gusto con la comuna en lugar de la provincia, por ello y para unificar proceso de backend como en el pos, se propone este PR para que en ambos lados la comuna sea el primer elemento que seleccionen los usuarios y al seleccionar la comuna se autocompleten los demas datos(provincia y pais)

Complementario al PR https://github.com/dansanti/l10n_cl_fe/pull/27

Por favor hacer merge o indicar alguna novedad.
